### PR TITLE
fix: don't crash the server when the API misbehaves

### DIFF
--- a/frontend/lib/api.js
+++ b/frontend/lib/api.js
@@ -1,0 +1,64 @@
+import fetch from 'node-fetch';
+
+const DEFAULT_TIMEOUT_MS = 5000;
+const BODY_SNIPPET_LENGTH = 200;
+
+// The API is not always well behaved: while it restarts it refuses connections,
+// and a proxy in front of it can answer with an HTML error page or an empty
+// body. Any of those used to throw straight out of getServerSideProps, which
+// Next.js does not catch — it killed the whole server process, taking every
+// concurrent request down with it.
+//
+// fetchJson never throws and never returns undefined. It always resolves to
+// { data, error }, so callers can return props and render a degraded page.
+export async function fetchJson(apiCall, { timeout = DEFAULT_TIMEOUT_MS, ...options } = {}) {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeout);
+
+  try {
+    const res = await fetch(apiCall, { ...options, signal: controller.signal });
+    // Read as text first: res.json() throws on an empty or non-JSON body and
+    // discards the payload, which is exactly what made this hard to debug.
+    const body = await res.text();
+
+    if (!res.ok) {
+      console.error(`API responded ${res.status} for ${apiCall}: ${snippet(body)}`);
+      return { data: null, error: { message: `The server responded with an error (${res.status})` } };
+    }
+
+    let data;
+    try {
+      data = JSON.parse(body);
+    } catch (e) {
+      console.error(`API returned invalid JSON for ${apiCall}: ${snippet(body)}`);
+      return { data: null, error: { message: 'The server returned an invalid response' } };
+    }
+
+    // `null`, a bare number or a string all parse cleanly but would throw the
+    // moment a caller reads a property off them. Every endpoint here returns an
+    // object or an array, so anything else is a failure.
+    if (data === null || typeof data !== 'object') {
+      console.error(`API returned an unexpected payload for ${apiCall}: ${snippet(body)}`);
+      return { data: null, error: { message: 'The server returned an unexpected response' } };
+    }
+
+    return { data, error: null };
+  } catch (e) {
+    if (e.name === 'AbortError') {
+      console.error(`API request timed out after ${timeout}ms for ${apiCall}`);
+      return { data: null, error: { message: 'The server took too long to respond' } };
+    }
+    console.error(`API request failed for ${apiCall}: ${e.message}`);
+    return { data: null, error: { message: 'Unable to reach the server' } };
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+// Logs what the API actually sent back — an empty body and an HTML error page
+// are indistinguishable from "invalid JSON" without it.
+function snippet(body) {
+  if (!body) return '<empty body>';
+  const collapsed = body.replace(/\s+/g, ' ').trim();
+  return collapsed.length > BODY_SNIPPET_LENGTH ? `${collapsed.slice(0, BODY_SNIPPET_LENGTH)}…` : collapsed;
+}

--- a/frontend/pages/[slug]/confirm_signature.js
+++ b/frontend/pages/[slug]/confirm_signature.js
@@ -4,6 +4,7 @@ import fetch from 'node-fetch';
 import Notification from '../../components/Notification';
 import Router, { withRouter } from 'next/router';
 import { withIntl } from '../../lib/i18n';
+import { fetchJson } from '../../lib/api';
 import DonorsList from '../../components/DonorsList';
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -102,14 +103,12 @@ class ConfirmSignaturePage extends Component {
 export async function getServerSideProps({ params, req }) {
   const apiCall = `${process.env.API_URL}/letters/${params.slug}`;
   console.log('>>> apiCall', apiCall);
-  const res = await fetch(apiCall);
-
-  try {
-    const letter = await res.json();
-    return { props: { letter } };
-  } catch (e) {
-    console.error('Unable to parse JSON returned by the API', e);
+  const { data: letter, error } = await fetchJson(apiCall);
+  if (error) {
+    return { props: { error } };
   }
+
+  return { props: { letter } };
 }
 
 export default withIntl(withRouter(ConfirmSignaturePage));

--- a/frontend/pages/[slug]/delete.js
+++ b/frontend/pages/[slug]/delete.js
@@ -9,6 +9,7 @@ import { typography, space } from 'styled-system';
 import LetterForm from '../../components/LetterForm';
 import Faq from '../../components/LetterForm-Faq';
 import Notification from '../../components/Notification';
+import { fetchJson } from '../../lib/api';
 import Router from 'next/router';
 import { withIntl } from '../../lib/i18n';
 
@@ -157,19 +158,17 @@ class DeleteLetterPage extends Component {
 export async function getServerSideProps({ params, req, query }) {
   const props = { headers: req.headers };
   const apiCall = `${process.env.API_URL}/letters/${params.slug}`;
-  const res = await fetch(apiCall);
-  try {
-    const response = await res.json();
-    if (response.error) {
-      props.error = response.error;
-    } else {
-      props.parentLetter = response;
-      props.token = query.token;
-    }
-    return { props };
-  } catch (e) {
-    console.error('Unable to parse JSON returned by the API', e);
+  const { data: response, error } = await fetchJson(apiCall);
+  if (error) {
+    props.error = error;
+  } else if (response.error) {
+    props.error = response.error;
+  } else {
+    props.parentLetter = response;
+    props.token = query.token;
   }
+
+  return { props };
 }
 
 export default withIntl(DeleteLetterPage);

--- a/frontend/pages/[slug]/index.js
+++ b/frontend/pages/[slug]/index.js
@@ -12,6 +12,7 @@ import SignaturesCount from '../../components/SignaturesCount';
 import Updates from '../../components/Updates';
 import LocaleSelector from '../../components/LocaleSelector';
 import { withIntl } from '../../lib/i18n';
+import { fetchJson } from '../../lib/api';
 import { replaceURLsWithMarkdownAnchors } from '../../lib/utils';
 import { registerPasskey } from '../../lib/passkey';
 import moment from 'moment';
@@ -233,48 +234,28 @@ export async function getServerSideProps({ params, req, res, locale }) {
   const apiCall = `${process.env.API_URL}/letters/${params.slug}?locale=${locale}&limit=${limit}`;
   console.log('>>> apiCall', apiCall);
 
-  // Create AbortController for timeout handling
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), 5000); // 5 second timeout
-
-  try {
-    const result = await fetch(apiCall, { signal: controller.signal });
-    clearTimeout(timeoutId); // Clear timeout if request succeeds
-
-    if (token) {
-      const signatureApiCall = `${process.env.API_URL}/signatures/${token}`;
-      const signatureResult = await fetch(signatureApiCall);
-      const signature = await signatureResult.json();
-      if (signature.error) {
-        props.error = signature.error;
-      } else {
-        signature.token = token;
-        props.signature = signature;
-      }
-    }
-
-    try {
-      const response = await result.json();
-      if (response.error) {
-        props.error = response.error;
-      } else {
-        props.letter = response;
-      }
-      return { props };
-    } catch (e) {
-      console.error('Unable to parse JSON returned by the API', e);
-    }
-  } catch (error) {
-    clearTimeout(timeoutId);
-    if (error.name === 'AbortError') {
-      console.error('API request timed out after 5 seconds');
-      props.error = { message: 'Request timeout' };
-    } else {
-      console.error('API request failed:', error);
-      props.error = { message: 'Request failed' };
-    }
-    return { props };
+  const { data: letter, error } = await fetchJson(apiCall);
+  if (error) {
+    props.error = error;
+  } else if (letter.error) {
+    props.error = letter.error;
+  } else {
+    props.letter = letter;
   }
+
+  if (token) {
+    const { data: signature, error: signatureError } = await fetchJson(`${process.env.API_URL}/signatures/${token}`);
+    if (signatureError) {
+      props.error = signatureError;
+    } else if (signature.error) {
+      props.error = signature.error;
+    } else {
+      signature.token = token;
+      props.signature = signature;
+    }
+  }
+
+  return { props };
 }
 
 export default withIntl(Letter);

--- a/frontend/pages/[slug]/update.js
+++ b/frontend/pages/[slug]/update.js
@@ -8,6 +8,7 @@ import { typography, space } from 'styled-system';
 import LetterForm from '../../components/LetterForm';
 import Faq from '../../components/LetterForm-Faq';
 import Notification from '../../components/Notification';
+import { fetchJson } from '../../lib/api';
 import Router from 'next/router';
 import { withIntl } from '../../lib/i18n';
 
@@ -88,6 +89,20 @@ class CreateLetterPage extends Component {
     const { status } = this.state;
     const { t, parentLetter } = this.props;
 
+    // parentLetter is missing whenever the API could not be reached — render a
+    // message instead of dereferencing undefined and blowing up the render.
+    if (!parentLetter) {
+      return (
+        <Page>
+          <div>
+            <h1>Not found</h1>
+            <p>This open letter cannot be found in the database.</p>
+          </div>
+          <Footer />
+        </Page>
+      );
+    }
+
     return (
       <>
         <TopBanner>
@@ -115,19 +130,17 @@ class CreateLetterPage extends Component {
 export async function getServerSideProps({ params, req, query }) {
   const props = { headers: req.headers };
   const apiCall = `${process.env.API_URL}/letters/${params.slug}`;
-  const res = await fetch(apiCall);
-  try {
-    const response = await res.json();
-    if (response.error) {
-      props.error = response.error;
-    } else {
-      props.parentLetter = response;
-      props.token = query.token;
-    }
-    return { props };
-  } catch (e) {
-    console.error('Unable to parse JSON returned by the API', e);
+  const { data: response, error } = await fetchJson(apiCall);
+  if (error) {
+    props.error = error;
+  } else if (response.error) {
+    props.error = response.error;
+  } else {
+    props.parentLetter = response;
+    props.token = query.token;
   }
+
+  return { props };
 }
 
 export default withIntl(CreateLetterPage);

--- a/frontend/pages/latest.js
+++ b/frontend/pages/latest.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import Link from 'next/link';
-import fetch from 'node-fetch';
+import { fetchJson } from '../lib/api';
 import Footer from '../components/Footer';
 import NumberFormat from 'react-number-format';
 import moment from 'moment';
@@ -9,10 +9,16 @@ const Badge = ({ children }) => (
     {children}
   </span>
 );
-function Index({ letters }) {
+function Index({ letters, error }) {
   return (
     <div className="p-6">
       <h1 className="text-2xl my-4">Latest open letters</h1>
+      {error && (
+        <p className="my-4 text-gray-600 dark:text-gray-400">
+          The list of letters could not be loaded right now. Please try again in a moment.
+        </p>
+      )}
+      {!error && letters.length === 0 && <p className="my-4 text-gray-600 dark:text-gray-400">No open letters yet.</p>}
       <ul>
         {letters.map((letter) => (
           <li className="my-2">
@@ -34,17 +40,16 @@ function Index({ letters }) {
 
 export async function getServerSideProps() {
   const apiCall = `${process.env.API_URL}/letters?limit=100&minSignatures=2`;
-  const res = await fetch(apiCall);
-  try {
-    const letters = await res.json();
-    return {
-      props: {
-        letters: letters,
-      },
-    };
-  } catch (e) {
-    console.error('Unable to parse JSON returned by the API', e);
-  }
+  const { data: letters, error } = await fetchJson(apiCall);
+
+  return {
+    props: {
+      // The API can answer 200 with something that is not a list; never hand
+      // the component anything it cannot map over.
+      letters: Array.isArray(letters) ? letters : [],
+      error: error || null,
+    },
+  };
 }
 
 export default Index;


### PR DESCRIPTION
## The problem

The production frontend has restarted **995 times** since 2026-05-13 (container `c4k0kc4s8kg0888ogwkgss0o`, deployed from `master` @ `c2d9a9e`). It is not a crash loop — the site recovers in about a second and looks healthy — but every crash drops all in-flight requests, so anyone loading a page in that window gets an error.

Restarts on 2026-08-10/11 alone: `17:41, 17:53, 18:30, 04:52, 07:08, 08:02, 11:50, 11:56`.

The signature in the logs is identical every time:

```
Unable to parse JSON returned by the API FetchError: invalid json response body
  at .../letters/<slug>?locale=en&limit=100
  reason: Unexpected token u in JSON at position 0
Error: Your `getServerSideProps` function did not return an object. Did you forget to add a `return`?
  at Server.<anonymous> (/app/node_modules/next/dist/server/next.js:1:1824)
```

`Unexpected token u at position 0` means the body was literally the string `undefined` — the API returned nothing parseable. `api.openletter.earth` has itself restarted 37 times; while it is down or restarting, the proxy answers with an empty body.

## Root cause

Two distinct ways every data-loading page could take the process down:

**1. A catch block that logs but never returns.** Present in all five pages:

```js
try {
  const response = await res.json();   // throws on an empty / non-JSON body
  return { props };
} catch (e) {
  console.error('Unable to parse JSON returned by the API', e);
}                                       // ← falls through, resolves to undefined
```

Next.js treats an `undefined` return as a fatal error and it escapes as an uncaught exception, which kills the Node process.

**2. An unguarded `await fetch(...)`.** `latest.js`, `confirm_signature.js`, `delete.js` and `update.js` never wrapped the fetch at all, so a refused connection threw straight out of `getServerSideProps`. Only `[slug]/index.js` guarded it.

## The fix

**New `frontend/lib/api.js`.** `fetchJson()` never throws and never returns undefined — it always resolves to `{ data, error }`:

- 5s timeout via `AbortController` (matching what `[slug]/index.js` already did)
- non-2xx responses become an error instead of being parsed
- reads the body as text first, then `JSON.parse` inside a try — so a failure can log **what the API actually sent** instead of discarding it
- rejects payloads that parse but aren't objects: `JSON.parse('null')` succeeds, and `null.error` would throw on the first property read, reintroducing the same crash through a different door

**All five pages** now always return a props object, and degrade instead of breaking:

| Page | Behaviour when the API is unavailable |
|---|---|
| `[slug]/index.js` | "Unable to load this letter" notification (already existed, now actually reachable) |
| `latest.js` | Explanatory message; `letters` is guaranteed to be an array, so the render can't throw on `.map` |
| `[slug]/confirm_signature.js` | Existing not-found notification |
| `[slug]/delete.js` | Existing not-found page |
| `[slug]/update.js` | **New** guard — it dereferenced `parentLetter.slug` with no check and would throw during render |

## Testing

- All six files pass a syntax check (esbuild, JSX loader) and `prettier --check` against the repo's `.prettierrc`
- No full `next build` was run — this is Next 10 / React 16 and installing the tree on Node 22 wasn't something I wanted to do against production tooling. **Worth a preview deploy before merging.**

## Not included

The API's own instability (37 restarts) is untouched — this PR makes the frontend survive it, not go away. Worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PrLRpgvF7QyeDdVxyZBi8T
