### PR TITLE
fix: stop background timers from killing the API process

### DIFF
--- a/api/app/Controllers/Http/LetterController.js
+++ b/api/app/Controllers/Http/LetterController.js
@@ -26,7 +26,12 @@ const latestSignatureTimestampByIpAddress = {};
 console.log('>>> Setting up latestSignatureTimestampByIpAddress');
 setInterval(() => {
   console.log('>>> Resetting latestSignatureTimestampByIpAddress');
-  latestSignatureTimestampByIpAddress = {};
+  // Clear the keys instead of reassigning: the binding is a const, and the
+  // reassignment threw "TypeError: Assignment to constant variable" once a day,
+  // inside a timer where nothing could catch it — killing the whole API.
+  for (const ipAddress of Object.keys(latestSignatureTimestampByIpAddress)) {
+    delete latestSignatureTimestampByIpAddress[ipAddress];
+  }
 }, 1000 * 60 * 60 * 24); // reset every day
 
 class LetterController {

--- a/api/app/Controllers/Http/MainController.js
+++ b/api/app/Controllers/Http/MainController.js
@@ -29,8 +29,13 @@ async function updateLatestLetters() {
 }
 
 function updateData() {
-  computeStats();
-  updateLatestLetters();
+  // Both of these are async, and their promises are not awaited. Without a
+  // catch, a single failed query (a connection blip, a pool timeout) becomes an
+  // unhandled rejection — which terminates the process on Node >= 15 and takes
+  // the API down with every request in flight. Stale stats for five minutes is
+  // the better failure mode.
+  computeStats().catch((e) => console.error('>>> failed to compute stats:', e.message));
+  updateLatestLetters().catch((e) => console.error('>>> failed to update latest letters:', e.message));
 }
 updateData();
 setInterval(updateData, 1000 * 60 * 5); // we recompute stats and latest letters every 5 minutes


### PR DESCRIPTION
Follow-up to #60. That PR makes the frontend survive a misbehaving API; this one fixes why the API misbehaves.

## The problem

`api.openletter.earth` has restarted **39 times** since 2026-05-02 (container `s40kooskogsgg0os4w0080sw`). Each restart takes ~2s, during which the frontend gets an empty body — which is exactly what was crashing it in #60.

Both causes are background timers. An exception in a timer isn't attached to a request, so Adonis' error handling never sees it, and on Node 16 (`node:16-alpine`) it terminates the process.

## 1. A daily TypeError in `LetterController.js`

```js
const latestSignatureTimestampByIpAddress = {};
setInterval(() => {
  latestSignatureTimestampByIpAddress = {};   // ← assignment to a const
}, 1000 * 60 * 60 * 24);
```

Caught in production on 2026-08-12 at 15:17:15 UTC:

```
TypeError: Assignment to constant variable.
    at Timeout._onTimeout (/app/app/Controllers/Http/LetterController.js:29:39)
    at listOnTimeout (node:internal/timers:559:17)
```

Every process that stays up for 24 hours dies at the 24-hour mark. There's a second bug hiding inside the first: because the reset always threw, **it never actually reset** — the IP map grows unbounded for the lifetime of each process, and the only thing that ever cleared it was the crash.

Fixed by clearing the keys in place, which keeps the `const` binding, fixes the crash, and makes the daily reset do its job. The map is module-local (used only at lines 271, 351, 381), so nothing else holds a reference to the old object.

## 2. An unhandled rejection every 5 minutes in `MainController.js`

```js
function updateData() {
  computeStats();          // async, not awaited, no catch
  updateLatestLetters();   // async, not awaited, no catch
}
setInterval(updateData, 1000 * 60 * 5);
```

Both hit the database. Any failed query — connection blip, pool timeout, a slow query during a backup — becomes an unhandled rejection, and Node ≥ 15 terminates the process by default. This runs 288 times a day, so it's the more likely source of the restarts that aren't exactly 24h apart.

Each call now has a `.catch` that logs. Stats go stale until the next tick instead of the API disappearing.

## Testing

Both files pass a syntax check and `prettier --check`. I did **not** run the Adonis test suite or boot the API locally — it needs Postgres and SMTP config. Both changes are small and local; still worth a staging deploy before merge.

## Noticed, not changed

`updateLatestLetters()` guards with `if (!letters.featured)`, but `letters.featured` is an object literal that's always truthy — so the featured-letters refresh has never run after startup. Left alone since fixing it changes behaviour rather than stability, but someone should decide whether that's intended.

If you'd like a belt-and-braces guard on top of these, a `process.on('unhandledRejection')` handler in `server.js` that logs instead of exiting would stop any *future* timer bug from taking the API down. I left it out deliberately: it also hides real bugs, and both known crash sources are now fixed at the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PrLRpgvF7QyeDdVxyZBi8T
